### PR TITLE
docs: fix few-shot flag hyphens in README

### DIFF
--- a/bda_benchmark/README_cross_event.md
+++ b/bda_benchmark/README_cross_event.md
@@ -156,7 +156,7 @@ python script/cross_event/one_shot/train_DamageFormer.py  --dataset 'BRIGHT' \
                                                           --val_data_list_path '<your project path>/bda_benchmark/dataset/splitname/standard_ML/val_set.txt' \
                                                           --test_dataset_path '<your dataset path>' \
                                                           --test_data_list_path '<your project path>/bda_benchmark/dataset/splitname/standard_ML/test_set.txt' \
-                                                          -train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
+                                                          --train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
                                                           --val_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/val_set.txt' \
                                                           --test_event_name 'hawaii-wildfire'
 ```
@@ -179,7 +179,7 @@ python script/cross_event/one_shot/train_MeanTeacher.py --dataset 'BRIGHT' \
                                                         --val_data_list_path '<your project path>/bda_benchmark/dataset/splitname/standard_ML/val_set.txt' \
                                                         --test_dataset_path '<your dataset path>' \
                                                         --test_data_list_path '<your project path>/bda_benchmark/dataset/splitname/standard_ML/test_set.txt' \
-                                                        -train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
+                                                        --train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
                                                         --val_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/val_set.txt' \
                                                         --test_event_name 'hawaii-wildfire'
 ```


### PR DESCRIPTION
### issue: #14 

### What

Correct the README example to use `--train_data_list_path_few_shot` (double hyphen) instead of `-train_data_list_path_few_shot`.

### Why

The training scripts (`train_MeanTeacher.py`, `train_DamageFormer.py`) only recognize the flag with two hyphens, so the existing README example fails.

### Change

```diff
-159 -train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
+159 --train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
....
-182 -train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
+182 --train_data_list_path_few_shot '<your project path>/bda_benchmark/dataset/splitname/few_shot/train_set.txt' \
```
Please review—thanks! 😊